### PR TITLE
Patch to address column definitions.

### DIFF
--- a/mssql/module_dim.yml.liquid
+++ b/mssql/module_dim.yml.liquid
@@ -48,7 +48,7 @@ out:
     require_sequential_progress: {type: 'VARCHAR(256) NULL'}
     workflow_state: {type: 'VARCHAR(256) NULL'}
     position: {type: 'INT NULL'}
-    name: {type: 'NVARCHAR(256) NULL'}
+    name: {type: 'NVARCHAR(MAX) NULL'}
     created_at: {value_type: timestamp, timestamp_format: '%Y-%m-%d %H:%M:%S.%L'}
     deleted_at: {value_type: timestamp, timestamp_format: '%Y-%m-%d %H:%M:%S.%L'}
     unlock_at: {value_type: timestamp, timestamp_format: '%Y-%m-%d %H:%M:%S.%L'}

--- a/mssql/module_dim.yml.liquid
+++ b/mssql/module_dim.yml.liquid
@@ -48,7 +48,7 @@ out:
     require_sequential_progress: {type: 'VARCHAR(256) NULL'}
     workflow_state: {type: 'VARCHAR(256) NULL'}
     position: {type: 'INT NULL'}
-    name: {type: 'NVARCHAR(MAX) NULL'}
+    name: {type: 'NVARCHAR(512) NULL'}
     created_at: {value_type: timestamp, timestamp_format: '%Y-%m-%d %H:%M:%S.%L'}
     deleted_at: {value_type: timestamp, timestamp_format: '%Y-%m-%d %H:%M:%S.%L'}
     unlock_at: {value_type: timestamp, timestamp_format: '%Y-%m-%d %H:%M:%S.%L'}

--- a/mysql/learning_outcome_dim.yml.liquid
+++ b/mysql/learning_outcome_dim.yml.liquid
@@ -48,7 +48,7 @@ out:
     account_id: {type: 'BIGINT NULL'}
     course_id: {type: 'BIGINT NULL'}
     short_description: {type: 'VARCHAR(256) NULL'}
-    description: {type: 'VARCHAR NULL'}
+    description: {type: 'LONGTEXT NULL'}
     workflow_state: {type: 'VARCHAR(256) NULL'}
     created_at: {type: 'DATETIME NULL', value_type: timestamp, timestamp_format: '%Y-%m-%d %H:%M:%S.%L'}
     updated_at: {type: 'DATETIME NULL', value_type: timestamp, timestamp_format: '%Y-%m-%d %H:%M:%S.%L'}

--- a/mysql/module_dim.yml.liquid
+++ b/mysql/module_dim.yml.liquid
@@ -46,7 +46,7 @@ out:
     require_sequential_progress: {type: 'VARCHAR(256) NULL'}
     workflow_state: {type: 'VARCHAR(256) NULL'}
     position: {type: 'INT NULL'}
-    name: {type: 'VARCHAR(256) NULL'}
+    name: {type: 'LONGTEXT NULL'}
     created_at: {type: 'DATETIME NULL', value_type: timestamp, timestamp_format: '%Y-%m-%d %H:%M:%S.%L'}
     deleted_at: {type: 'DATETIME NULL', value_type: timestamp, timestamp_format: '%Y-%m-%d %H:%M:%S.%L'}
     unlock_at: {type: 'DATETIME NULL', value_type: timestamp, timestamp_format: '%Y-%m-%d %H:%M:%S.%L'}

--- a/mysql/module_dim.yml.liquid
+++ b/mysql/module_dim.yml.liquid
@@ -46,7 +46,7 @@ out:
     require_sequential_progress: {type: 'VARCHAR(256) NULL'}
     workflow_state: {type: 'VARCHAR(256) NULL'}
     position: {type: 'INT NULL'}
-    name: {type: 'LONGTEXT NULL'}
+    name: {type: 'VARCHAR(512) NULL'}
     created_at: {type: 'DATETIME NULL', value_type: timestamp, timestamp_format: '%Y-%m-%d %H:%M:%S.%L'}
     deleted_at: {type: 'DATETIME NULL', value_type: timestamp, timestamp_format: '%Y-%m-%d %H:%M:%S.%L'}
     unlock_at: {type: 'DATETIME NULL', value_type: timestamp, timestamp_format: '%Y-%m-%d %H:%M:%S.%L'}

--- a/oracle/module_dim.yml.liquid
+++ b/oracle/module_dim.yml.liquid
@@ -45,7 +45,7 @@ out:
     require_sequential_progress: {type: 'VARCHAR(256) NULL'}
     workflow_state: {type: 'VARCHAR(256) NULL'}
     position: {type: 'NUMBER NULL'}
-    name: {type: 'CLOB NULL'}
+    name: {type: 'VARCHAR(512) NULL'}
     created_at: {type: 'DATE NULL', value_type: timestamp, timestamp_format: '%Y-%m-%d %H:%M:%S.%L'}
     deleted_at: {type: 'DATE NULL', value_type: timestamp, timestamp_format: '%Y-%m-%d %H:%M:%S.%L'}
     unlock_at: {type: 'DATE NULL', value_type: timestamp, timestamp_format: '%Y-%m-%d %H:%M:%S.%L'}

--- a/oracle/module_dim.yml.liquid
+++ b/oracle/module_dim.yml.liquid
@@ -45,7 +45,7 @@ out:
     require_sequential_progress: {type: 'VARCHAR(256) NULL'}
     workflow_state: {type: 'VARCHAR(256) NULL'}
     position: {type: 'NUMBER NULL'}
-    name: {type: 'VARCHAR(256) NULL'}
+    name: {type: 'CLOB NULL'}
     created_at: {type: 'DATE NULL', value_type: timestamp, timestamp_format: '%Y-%m-%d %H:%M:%S.%L'}
     deleted_at: {type: 'DATE NULL', value_type: timestamp, timestamp_format: '%Y-%m-%d %H:%M:%S.%L'}
     unlock_at: {type: 'DATE NULL', value_type: timestamp, timestamp_format: '%Y-%m-%d %H:%M:%S.%L'}

--- a/postgres/module_dim.yml.liquid
+++ b/postgres/module_dim.yml.liquid
@@ -46,7 +46,7 @@ out:
     require_sequential_progress: {type: 'VARCHAR(256) NULL'}
     workflow_state: {type: 'VARCHAR(256) NULL'}
     position: {type: 'INT NULL'}
-    name: {type: 'VARCHAR(256) NULL'}
+    name: {type: 'VARCHAR NULL'}
     created_at: {value_type: timestamp, timestamp_format: '%Y-%m-%d %H:%M:%S.%L'}
     deleted_at: {value_type: timestamp, timestamp_format: '%Y-%m-%d %H:%M:%S.%L'}
     unlock_at: {value_type: timestamp, timestamp_format: '%Y-%m-%d %H:%M:%S.%L'}

--- a/postgres/module_dim.yml.liquid
+++ b/postgres/module_dim.yml.liquid
@@ -46,7 +46,7 @@ out:
     require_sequential_progress: {type: 'VARCHAR(256) NULL'}
     workflow_state: {type: 'VARCHAR(256) NULL'}
     position: {type: 'INT NULL'}
-    name: {type: 'VARCHAR NULL'}
+    name: {type: 'VARCHAR(512) NULL'}
     created_at: {value_type: timestamp, timestamp_format: '%Y-%m-%d %H:%M:%S.%L'}
     deleted_at: {value_type: timestamp, timestamp_format: '%Y-%m-%d %H:%M:%S.%L'}
     unlock_at: {value_type: timestamp, timestamp_format: '%Y-%m-%d %H:%M:%S.%L'}


### PR DESCRIPTION
In the v4.2.4 schema the following columns are listed as 'text' type columns.

.   learning_outcome_dim.description
.   module_dim.name

In the MySQL specific liquid files, the learning_outcome_dim table was failing
to be generated at all (due to a DDL syntax error).  The module_dim.name
column was too short for some of our actual data and that was generating an
error.  I went back to the `schema.json` and made adjustment to both file
(fixing the syntax error and adjusting the column spec).

I also applied similar changes to the MSSQL, Oracle, and PostgresQL variants.
I am unable to verify that these are syntactically correct, but they match
the similar constructs for other tables in their respective dialects.